### PR TITLE
Add missing 'repository' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "make test",
     "prepublish": "make clean build"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/acdlite/flux-standard-action.git"
+  },
   "keywords": [
     "flux",
     "redux",


### PR DESCRIPTION
I noticed that the npm page didn't have a link to this repo.