### PR TITLE
Fix meta property declaration to be optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ export interface FluxStandardAction<Payload, Meta> {
    * The optional `meta` property MAY be any type of value.
    * It is intended for any extra information that is not part of the payload.
    */
-  meta: Meta;
+  meta?: Meta;
 }
 
 export interface ErrorFluxStandardAction<CustomError extends Error, Meta> extends FluxStandardAction<CustomError, Meta> {

--- a/test/typings-test.ts
+++ b/test/typings-test.ts
@@ -47,9 +47,11 @@ function reducer(state, action) {
   }
   else if (isFSA<CustomPayload, CustomMetadata>(action)) {
     let a: number = action.payload.a;
-    let b: string = action.meta.b;
+    if (action.meta) {
+      let b: string = action.meta.b;
+    }
   }
-  else if (isFSA<void, string>(action)) {
+  else if (isFSA<void, string>(action) && action.meta) {
     let meta: string = action.meta;
   }
   else if (isError(action)) {
@@ -68,9 +70,11 @@ function reducer2(state, action) {
   }
   else if (isCustomAction2(action)) {
     let a: number = action.payload.a;
-    let b: string = action.meta.b;
+    if (action.meta) {
+      let b: string = action.meta.b;
+    }
   }
-  else if (isCustomAction3(action)) {
+  else if (isCustomAction3(action) && action.meta) {
     let meta: string = action.meta;
   }
 }


### PR DESCRIPTION
According to the comment immediately above the property, `meta` is supposed to be optional. This PR brings the type description in line with that sentiment.