### PR TITLE
fix(typings): make `meta` property optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ export interface FluxStandardAction<Payload, Meta> {
    * The optional `meta` property MAY be any type of value.
    * It is intended for any extra information that is not part of the payload.
    */
-  meta: Meta;
+  meta?: Meta;
 }
 
 export interface ErrorFluxStandardAction<CustomError extends Error, Meta> extends FluxStandardAction<CustomError, Meta> {


### PR DESCRIPTION
This PR corrects the interface definition for `FluxStandardAction`, making the `meta` property optional.