### PR TITLE
Make `meta` property optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-standard-action",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A human-friendly standard for Flux action objects",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ export interface FluxStandardAction<Payload, Meta> {
    * The optional `meta` property MAY be any type of value.
    * It is intended for any extra information that is not part of the payload.
    */
-  meta: Meta;
+  meta?: Meta;
 }
 
 export interface ErrorFluxStandardAction<CustomError extends Error, Meta> extends FluxStandardAction<CustomError, Meta> {


### PR DESCRIPTION
This PR corrects the interface definition for `FluxStandardAction`, making the `meta` property optional.