### PR TITLE
docs: Document isError function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,20 @@ The optional `meta` property MAY be any type of value. It is intended for any ex
 
 The module `flux-standard-action` is available on npm. It exports a few utility functions.
 
+### `isFSA(action)`
+
 ```js
 import { isFSA } from 'flux-standard-action';
 ```
-### `isFSA(action)`
-
 Returns true if `action` is FSA compliant.
+
+
+### `isError(action)`
+
+```js
+import { isError } from 'flux-standard-action';
+```
+Returns true if `action` represents error.
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Returns true if `action` is FSA compliant.
 ```js
 import { isError } from 'flux-standard-action';
 ```
-Returns true if `action` represents error.
+Returns true if `action` represents an error.
 
 ## Libraries
 


### PR DESCRIPTION
Somehow I was able to [miss this function](https://github.com/acdlite/flux-standard-action/issues/92) in code so it would be nice to have it documented.