### PR TITLE
fix: add isFSA check to isError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export function isFSA(action) {
 }
 
 export function isError(action) {
-  return action.error === true;
+  return isFSA(action) && action.error === true;
 }
 
 function isValidKey(key) {


### PR DESCRIPTION
This prevents potential `TypeError`s due to property access to `null` and `undefined`, and also make sure `action` is actually a FSA-complaint action object.